### PR TITLE
Syntax error in install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,8 @@ install_requires = [{
     # List your project dependencies here.
     # For more details, see:
     # http://packages.python.org/distribute/setuptools.html#declaring-dependencies
-    'requests'
-    'beautifulsoup4'
+    'requests',
+    'beautifulsoup4',
     'tinydb'
     }
 ]


### PR DESCRIPTION
Missing commas between the package dependencies causing the install via PIP to fail (looks for the package "requestsbeautifulsoup4tinydb" and understandably can't find it :).